### PR TITLE
Email jsdelivr links for 2025 data

### DIFF
--- a/.github/workflows/eprx_results.yml
+++ b/.github/workflows/eprx_results.yml
@@ -97,5 +97,79 @@ jobs:
             - Committed back to the manager's repository
             - Pushed to public repo [opendenki/eprx](https://github.com/opendenki/eprx)
 
+            jsDelivr CDN links for 2025 files:
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_1-0_prompt/202504_1-0_prompt.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_1-0_prompt/202505_1-0_prompt.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_1-0_prompt/202506_1-0_prompt.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_1-0_prompt/202507_1-0_prompt.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_1-0_prompt/202508_1-0_prompt.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_1-0_result/202504_1-0_result.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_1-0_result/202505_1-0_result.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_1-0_result/202506_1-0_result.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_1-1_prompt/202504_1-1_prompt.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_1-1_prompt/202505_1-1_prompt.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_1-1_prompt/202506_1-1_prompt.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_1-1_prompt/202507_1-1_prompt.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_1-1_prompt/202508_1-1_prompt.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_1-1_result/202504_1-1_result.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_1-1_result/202505_1-1_result.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_1-1_result/202506_1-1_result.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_2-1_prompt/202504_2-1_prompt.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_2-1_prompt/202505_2-1_prompt.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_2-1_prompt/202506_2-1_prompt.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_2-1_prompt/202507_2-1_prompt.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_2-1_prompt/202508_2-1_prompt.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_2-1_result/202504_2-1_result.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_2-1_result/202505_2-1_result.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_2-1_result/202506_2-1_result.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_2-2_prompt/202504_2-2_prompt.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_2-2_prompt/202505_2-2_prompt.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_2-2_prompt/202506_2-2_prompt.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_2-2_prompt/202507_2-2_prompt.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_2-2_prompt/202508_2-2_prompt.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_2-2_result/202504_2-2_result.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_2-2_result/202505_2-2_result.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_2-2_result/202506_2-2_result.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_3-1_prompt/202504_3-1_prompt.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_3-1_prompt/202505_3-1_prompt.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_3-1_prompt/202506_3-1_prompt.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_3-1_prompt/202507_3-1_prompt.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_3-1_prompt/202508_3-1_prompt.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_3-1_result/202504_3-1_result.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_3-1_result/202505_3-1_result.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_3-1_result/202506_3-1_result.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_3-2_prompt/202504_3-2_prompt.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_3-2_prompt/202505_3-2_prompt.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_3-2_prompt/202506_3-2_prompt.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_3-2_prompt/202507_3-2_prompt.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_3-2_prompt/202508_3-2_prompt.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_3-2_result/202504_3-2_result.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_3-2_result/202505_3-2_result.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_3-2_result/202506_3-2_result.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_4-0_prompt/202504_4-0_prompt.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_4-0_prompt/202505_4-0_prompt.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_4-0_prompt/202506_4-0_prompt.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_4-0_prompt/202507_4-0_prompt.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_4-0_prompt/202508_4-0_prompt.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_4-0_result/202504_4-0_result.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_4-0_result/202505_4-0_result.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_4-0_result/202506_4-0_result.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_tieline_daily_prompt/202504_tieline_daily_prompt.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_tieline_daily_prompt/202505_tieline_daily_prompt.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_tieline_daily_prompt/202506_tieline_daily_prompt.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_tieline_daily_prompt/202507_tieline_daily_prompt.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_tieline_daily_prompt/202508_tieline_daily_prompt.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_tieline_daily_result/202504_tieline_daily_result.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_tieline_daily_result/202505_tieline_daily_result.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_tieline_daily_result/202506_tieline_daily_result.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_tieline_weekly_prompt/202504_tieline_weekly_prompt.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_tieline_weekly_prompt/202505_tieline_weekly_prompt.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_tieline_weekly_prompt/202506_tieline_weekly_prompt.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_tieline_weekly_prompt/202507_tieline_weekly_prompt.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_tieline_weekly_prompt/202508_tieline_weekly_prompt.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_tieline_weekly_result/202504_tieline_weekly_result.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_tieline_weekly_result/202505_tieline_weekly_result.csv
+            - https://cdn.jsdelivr.net/gh/dlxiii/eprx_scraper@main/zip/2025_tieline_weekly_result/202506_tieline_weekly_result.csv
+
             📎 View workflow logs:
             ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
## Summary
- remove standalone `zip/2025_jsdelivr_links.txt`
- include jsDelivr CDN links for all 2025 CSV files in workflow notification email body

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688b8e944b0c83209bc75d09dad518ac