### PR TITLE
fix: correct CDN file naming for all reserve types

### DIFF
--- a/.github/workflows/eprx_results.yml
+++ b/.github/workflows/eprx_results.yml
@@ -79,37 +79,54 @@ jobs:
           git commit -m "Auto sync EPRX results for ${FISCAL_YEAR}" || echo "No changes to commit"
           git push
 
-        - name: Prepare CDN file names
-          run: |
-            python - <<'PYTHON' >> "$GITHUB_ENV"
-            from datetime import date
-            import os
+      - name: Prepare CDN file names
+        run: |
+          python - <<'PYTHON' >> "$GITHUB_ENV"
+          from datetime import date
+          import os
 
-            today = date.today()
-            version = "1-0"
-            fiscal_year = os.environ.get("FISCAL_YEAR", today.strftime("%Y"))
+          today = date.today()
+          fiscal_year = os.environ.get("FISCAL_YEAR", today.strftime("%Y"))
+          reserve_product_names = [
+              "1-0",
+              "1-1",
+              "2-1",
+              "2-2",
+              "3-1",
+              "3-2",
+              "4-0",
+              "tieline_daily",
+              "tieline_weekly",
+          ]
 
-            prompt_folder = f"{fiscal_year}_{version}_prompt"
-            result_folder = f"{fiscal_year}_{version}_result"
+          if today.month == 12:
+              next_year, next_month = today.year + 1, 1
+          else:
+              next_year, next_month = today.year, today.month + 1
 
-            if today.month == 12:
-                next_year, next_month = today.year + 1, 1
-            else:
-                next_year, next_month = today.year, today.month + 1
+          if today.month == 1:
+              prev_year, prev_month = today.year - 1, 12
+          else:
+              prev_year, prev_month = today.year, today.month - 1
 
-            if today.month == 1:
-                prev_year, prev_month = today.year - 1, 12
-            else:
-                prev_year, prev_month = today.year, today.month - 1
+          repo = os.environ.get("GITHUB_REPOSITORY")
+          links = []
+          for reserve_product_name in reserve_product_names:
+              prompt_folder = f"{fiscal_year}_{reserve_product_name}_prompt"
+              result_folder = f"{fiscal_year}_{reserve_product_name}_result"
+              prompt_file = f"{next_year}{next_month:02d}_{reserve_product_name}_prompt.csv"
+              result_file = f"{prev_year}{prev_month:02d}_{reserve_product_name}_result.csv"
+              links.append(
+                  f"- https://cdn.jsdelivr.net/gh/{repo}@main/zip/{prompt_folder}/{prompt_file}"
+              )
+              links.append(
+                  f"- https://cdn.jsdelivr.net/gh/{repo}@main/zip/{result_folder}/{result_file}"
+              )
 
-            prompt_file = f"{next_year}{next_month:02d}_{version}_prompt.csv"
-            result_file = f"{prev_year}{prev_month:02d}_{version}_result.csv"
-
-            print(f"PROMPT_FOLDER={prompt_folder}")
-            print(f"RESULT_FOLDER={result_folder}")
-            print(f"PROMPT_FILE={prompt_file}")
-            print(f"RESULT_FILE={result_file}")
-            PYTHON
+          print("CDN_LINKS<<EOF")
+          print("\n".join(links))
+          print("EOF")
+          PYTHON
 
       - name: Send notification email
         uses: dawidd6/action-send-mail@v3
@@ -130,12 +147,14 @@ jobs:
             - Pushed to public repo [opendenki/eprx](https://github.com/opendenki/eprx)
 
             jsDelivr CDN naming rules:
-            - Folders: yyyy_1-0_prompt or yyyy_1-0_result
-            - CSV files: yyyymm_1-0_prompt.csv (next month) or yyyymm_1-0_result.csv (previous month)
+            - Folders: yyyy_<reserve_product_name>_prompt or yyyy_<reserve_product_name>_result
+              where <reserve_product_name> is one of:
+              1-0, 1-1, 2-1, 2-2, 3-1, 3-2, 4-0, tieline_daily, tieline_weekly
+            - CSV files: yyyymm_<reserve_product_name>_prompt.csv (next month)
+              or yyyymm_<reserve_product_name>_result.csv (previous month)
 
             jsDelivr CDN links:
-            - https://cdn.jsdelivr.net/gh/${{ github.repository }}@main/zip/${{ env.PROMPT_FOLDER }}/${{ env.PROMPT_FILE }}
-            - https://cdn.jsdelivr.net/gh/${{ github.repository }}@main/zip/${{ env.RESULT_FOLDER }}/${{ env.RESULT_FILE }}
+            ${{ env.CDN_LINKS }}
 
             📎 View workflow logs:
             ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
## Summary
- generate jsDelivr links for all reserve and tie line result/prompt files
- clarify file naming rules in notification email
- rename `versions` placeholder to `reserve_product_name`

## Testing
- `python -m py_compile eprx_scraper.py run_eprx_results.py`
- `yamllint .github/workflows/eprx_results.yml` *(line-length errors, file still valid)*

------
https://chatgpt.com/codex/tasks/task_e_688b9ac1d614832084dc444b22ec6255